### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/OsmSharp.IO.API/ClientsFactory.cs
+++ b/OsmSharp.IO.API/ClientsFactory.cs
@@ -12,7 +12,7 @@ namespace OsmSharp.IO.API
         /// <summary>
         /// The URL of the production instance of OSM's API. Use with care.
         /// </summary>
-        public const string PRODUCTION_URL = @"https://www.openstreetmap.org/api/";
+        public const string PRODUCTION_URL = @"https://api.openstreetmap.org/api/";
 
         /// <summary>
         /// The URL of the development instance of OSM's API. The correct place to do testing.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pull requests are welcome. You will need VisualStudio, VS Code or Rider to modif
 // Create a client factory (pointing at the dev server)
 var clientFactory = new ClientsFactory(null, new HttpClient(),
 	"https://master.apis.dev.openstreetmap.org/api/");
-// After testing, use "https://www.openstreetmap.org/api/" for production
+// After testing, use "https://api.openstreetmap.org/api/" for production
 ```
 
 ### Get a Node


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)